### PR TITLE
slim down Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,25 @@
-FROM golang:1.20.7-alpine
-
-RUN addgroup -S -g 1000 yadmb \
-  && adduser -S -G yadmb -u 999 yadmb \
-  && mkdir /app \
-  && chown yadmb:yadmb /app
+FROM golang:alpine AS build
 
 RUN apk add --no-cache \
-  git \
   g++ \
-  make \
+  git \
+  make
+
+RUN git clone https://github.com/TheTipo01/YADMB /src
+WORKDIR /src
+RUN go mod download
+RUN go build -trimpath github.com/bwmarrin/dca/cmd/dca
+RUN strip dca
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o yadmb
+
+FROM alpine
+
+RUN apk add --no-cache \
   ffmpeg \
   opus \
   yt-dlp
 
-USER yadmb
+COPY --from=build /src/yadmb /usr/bin/
+COPY --from=build /src/dca /usr/bin/
 
-WORKDIR /app
-
-RUN git clone https://github.com/TheTipo01/YADMB . \
-  && go mod download \
-  && go get -d github.com/bwmarrin/dca/cmd/dca \
-  && go install github.com/bwmarrin/dca/cmd/dca
-
-RUN go build -o build \
-  && chmod +x ./build
-
-CMD ["/app/build"]
+CMD ["yadmb"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,5 +6,5 @@ services:
       dockerfile: Dockerfile
     restart: always
     volumes:
-      - ./audio_cache:/app/audio_cache
-      - ./data:/app/data
+      - ./audio_cache:/audio_cache
+      - ./data:/data

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TheTipo01/YADMB
 go 1.14
 
 require (
+	github.com/bwmarrin/dca/cmd/dca v0.0.0-20221003192631-e7cc179f7b56
 	github.com/bwmarrin/discordgo v0.27.2-0.20230816134654-ff9176adccb6
 	github.com/bwmarrin/lit v0.0.0-20190813132558-fd4b44871312
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -772,6 +772,8 @@ github.com/apache/arrow/go/v12 v12.0.0/go.mod h1:d+tV/eHZZ7Dz7RPrFKtPK02tpr+c9/P
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bwmarrin/dca/cmd/dca v0.0.0-20221003192631-e7cc179f7b56 h1:vHbbSFbseUS3xnRE8KGBZS1zmCpcV0xWgZgLA2mWyMc=
+github.com/bwmarrin/dca/cmd/dca v0.0.0-20221003192631-e7cc179f7b56/go.mod h1:/1QUxKOPVOvY0BK5S7Tn8R19Vlah9ctcyeg0xWFGiXw=
 github.com/bwmarrin/discordgo v0.27.2-0.20230816134654-ff9176adccb6 h1:4htHaHl1onoc5NgASwhAiD+5JTOS2Ppv5AET2tR3iGw=
 github.com/bwmarrin/discordgo v0.27.2-0.20230816134654-ff9176adccb6/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/lit v0.0.0-20190813132558-fd4b44871312 h1:g5NUBR8yN3F2RWN4vrkd8wVr7vyLxr0hbq4I6PAZQc0=
@@ -1796,6 +1798,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+layeh.com/gopus v0.0.0-20210501142526-1ee02d434e32 h1:/S1gOotFo2sADAIdSGk1sDq1VxetoCWr6f5nxOG0dpY=
+layeh.com/gopus v0.0.0-20210501142526-1ee02d434e32/go.mod h1:yDtyzWZDFCVnva8NGtg38eH2Ns4J0D/6hD+MMeUGdF0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.3.0 h1:cDdUVfRwDUDovz610ABgFD17nXD4/uDgVHl2sC3+sbo=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,5 @@
+//go:build tools
+
+package main
+
+import _ "github.com/bwmarrin/dca/cmd/dca"


### PR DESCRIPTION
This patchset:
- fixes the dca version
- slims down the Docker image a bit (3.68 GB → 180 MB)